### PR TITLE
Chocolatey installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 /_launched_
 
 /out
+*.nupkg

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ so, I made it.
 
 ## Downloads
 
-Go to [Releases](https://github.com/appetizermonster/Hain/releases), then you can download prebuilt binaries.  
+Go to [Releases](https://github.com/appetizermonster/Hain/releases), then you can download prebuilt binaries.
+
+Alternatively, you can install Hain from the command prompt via [Chocolatey](https://chocolatey.org/packages/Hain):
+
+```ps
+cinst Hain -pre
+```
 
 ## Usage
 Run and press `alt+space` anywhere

--- a/chocolatey/Hain.nuspec
+++ b/chocolatey/Hain.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Hain</id>
+    <version>0.0.2-rc4</version>
+    <title>Hain</title>
+    <authors>Heejin Lee</authors>
+    <owners>FlorianRappl</owners>
+    <licenseUrl>https://github.com/appetizermonster/hain/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/appetizermonster/hain/</projectUrl>
+    <releaseNotes>https://github.com/appetizermonster/hain/releases</releaseNotes>
+    <packageSourceUrl>https://github.com/appetizermonster/hain/tree/master/chocolatey</packageSourceUrl>
+    <projectSourceUrl>https://github.com/appetizermonster/hain</projectSourceUrl>
+    <docsUrl>https://github.com/appetizermonster/hain/tree/master/docs</docsUrl>
+    <bugTrackerUrl>https://github.com/appetizermonster/hain/issues</bugTrackerUrl>
+    <iconUrl>https://raw.githubusercontent.com/appetizermonster/hain/master/build/icon.ico</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>An 'alt+space' launcher for Windows, built with Electron.</description>
+    <summary>An alternative to Alfred on Windows, that is made with JavaScript.</summary>
+    <tags>alfred hain windows electron launcher javascript program</tags>
+  </metadata>
+  <files>
+    <file src="tools\*.*" target="tools" />
+  </files>
+</package>

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 $packageName = 'Hain'
-$installerType = 'exe'
+$installerType = 'exe' # Squirell Installer / Updater
 $url32 = 'https://github.com/appetizermonster/hain/releases/download/v0.0.2-rc4/HainSetup-ia32.exe'
+$url64 = $url32 # At the moment there is no dedicated 64-bit version
+$silentArgs = "" # The installation is silent by default
  
-Install-ChocolateyPackage "$packageName" "$installerType" "$url32"
+Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url32" "$url64"

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,5 @@
+$packageName = 'Hain'
+$installerType = 'exe'
+$url32 = 'https://github.com/appetizermonster/hain/releases/download/v0.0.2-rc4/HainSetup-ia32.exe'
+ 
+Install-ChocolateyPackage "$packageName" "$installerType" "$url32"


### PR DESCRIPTION
Added a Chocolatey installer (as described in https://github.com/chocolatey/choco/wiki/CreatePackages). Also pushed the Chocolatey package (preliminary version).

If desired I can add you as the owner of the package (you need an account on the Chocolatey website though), such that you can also submit releases (e.g., via an installation script / in the CI with AppVeyor).