### PR TITLE
Add unix support

### DIFF
--- a/app/main-es6/conf.js
+++ b/app/main-es6/conf.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const path = require('path');
+const applicationConfigPath = require('application-config-path');
 
-const HAIN_USER_PATH = `${process.env.LOCALAPPDATA}/hain-user`;
+const HAIN_USER_PATH = applicationConfigPath('hain-user');
 const LOCAL_STORAGE_DIR = `${HAIN_USER_PATH}/localStorages`;
 const PLUGIN_PREF_DIR = `${HAIN_USER_PATH}/prefs/plugins`;
 const APP_PREF_DIR = `${HAIN_USER_PATH}/prefs/app`;

--- a/app/main-es6/plugins/hain-package-manager/package-control.js
+++ b/app/main-es6/plugins/hain-package-manager/package-control.js
@@ -112,6 +112,7 @@ function* installPackage(packageName, versionRange, destDir, tempDir) {
       yield gens;
     }
   } catch (e) {
+    console.log(e);
   }
 
   yield fileutil.move(incompleteDir, destDir);

--- a/app/main-es6/server/app/tray.js
+++ b/app/main-es6/server/app/tray.js
@@ -15,7 +15,10 @@ function* createTray() {
   const prefWindow = require('./prefwindow');
   const app = require('./app');
 
-  const iconPath = path.normalize(`${__dirname}/../../../images/tray_16.ico`);
+  const iconPath = process.platform !== 'linux' ?
+    path.normalize(`${__dirname}/../../../images/tray_16.ico`) :
+    path.normalize(`${__dirname}/../../../images/hain.png`);
+
   const autoLaunchActivated = yield autolaunch.isActivated();
   tray = new Tray(iconPath);
   const menu = Menu.buildFromTemplate([

--- a/app/main-es6/utils/fileutil.js
+++ b/app/main-es6/utils/fileutil.js
@@ -18,7 +18,7 @@ self.extractTarball = function (filePath, destPath) {
 
 self.move = function (src, dst) {
   return new Promise((resolve, reject) => {
-    fs.move(src, dst, (err) => {
+    fs.move(src, dst, { clobber: true }, (err) => {
       if (err) return reject(err);
       return resolve();
     });

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "author": "Heejin Lee <monster@teamappetizer.com>",
   "license": "MIT",
   "dependencies": {
+    "application-config-path": "^0.1.0",
     "co": "^4.6.0",
     "electron-squirrel-startup": "^0.1.4",
     "fs-extra": "^0.26.5",

--- a/app/platform-util/index.js
+++ b/app/platform-util/index.js
@@ -1,6 +1,13 @@
 'use strict';
 
-var native = require('./addon');
+var native = /^win/.test(process.platform) ? require('./addon') : {
+  fetchFileIconAsPng: function(path, cb) {
+    cb([]);
+  },
+  saveFocus: function() {},
+  restoreFocus: function() {}
+};
+
 var wrapper = {};
 
 wrapper.fetchFileIconAsPng = function (filePath, callback) {

--- a/run.js
+++ b/run.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const electronPath = require('electron-prebuilt');
+const childProcess = require('child_process');
+
+const args = process.argv.slice(2);
+args.unshift(__dirname);
+
+childProcess.spawn(electronPath, args, { stdio: 'inherit' });


### PR DESCRIPTION
Work in progress (https://github.com/appetizermonster/hain/issues/14)

How to test:

```
$ git clone https://github.com/ewnd9/hain.git && cd hain
$ git fetch && git checkout unix-support
$ npm install
$ node_modules/.bin/gulp
$ HAIN_SHORTCUT="super+v" ./run.js
```

List of available combinations for `HAIN_SHORTCUT` can be found at https://github.com/atom/electron/blob/master/docs/api/accelerator.md 

@appetizermonster I am especially not sure about `hain-package-manager` related part. `clobber` option is for replacing `dst` folder otherwise that [line](https://github.com/ewnd9/hain/blob/d2ca93d64852b0a1ffddf33eae9b45f153612998/app/main-es6/plugins/hain-package-manager/package-control.js#L61)  throws an exception (a folder already exists, [code](https://github.com/ewnd9/hain/blob/d2ca93d64852b0a1ffddf33eae9b45f153612998/app/main-es6/plugins/hain-package-manager/package-control.js#L73) which creates the folder). Is it ok to move a folder to already existed in order to replace it?

After adding a way to configure the shortcut (https://github.com/appetizermonster/hain/issues/13), I will rebase the pull request
 
// cc @Metrakit (https://github.com/Metrakit/hain-plugin-money/issues/1#issuecomment-201407422)