### PR TITLE
added hain-plugin-shortcut in docs

### DIFF
--- a/docs/plugin-docs.md
+++ b/docs/plugin-docs.md
@@ -22,6 +22,7 @@
 * [hain-plugin-amzn](https://github.com/TheBuzzDee/hain-plugin-amzn)
 * [hain-plugin-buzzpics](https://github.com/TheBuzzDee/hain-plugin-buzzpics)
 * [hain-plugin-notes](https://github.com/jervant/hain-plugin-notes)
+* [hain-plugin-shortcut](https://github.com/e-/hain-plugin-shortcut)
 
 ## Guides
 


### PR DESCRIPTION
Hello. 

I've created a simple plugin that launches an executable with a shortcut command (e.g., "v" for Visual Studio) since I am too lazy to type full names. I listed the plugin in docs. Hope you approve this. Thanks!