### PR TITLE
Debian release setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ npm run dev
 npm run build
 ```
 
+### Build from Source a deb package for Linux
+
+```shell
+npm run build-debian
+```
+
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)  
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,12 +33,12 @@ gulp.task('renderer', ['deps', 'clean:renderer'], () => {
   return js;
 });
 
-function build(arch) {
+function build(arch, platform) {
   return new Promise((resolve, reject) => {
     packager({
       arch,
       dir: path.join(__dirname, 'app'),
-      platform: 'win32',
+      platform: platform || 'win32',
       asar: true,
       ignore: /(renderer-jsx|__tests__)/gi,
       overwrite: true,
@@ -82,6 +82,26 @@ function buildInstaller(arch) {
   });
 }
 
+function buildDebianPkg() {
+  const electronDebianPkg = require('electron-installer-debian');
+  const options = {
+    src: 'out/hain-linux-x64/',
+    dest: 'out/installers/',
+    arch: 'amd64'
+  };
+
+  return new Promise((resolve, reject) => {
+    electronDebianPkg(options, function (err) {
+      if (err) {
+        console.log(err);
+        return reject(err);
+      }
+
+      return resolve();
+    });
+  });
+}
+
 gulp.task('build', ['renderer', 'deps'], () => {
   return build('ia32')
     .then(() => build('x64'));
@@ -90,6 +110,11 @@ gulp.task('build', ['renderer', 'deps'], () => {
 gulp.task('build-zip-ia32', ['build'], () => buildZip('ia32'));
 gulp.task('build-zip-x64', ['build'], () => buildZip('x64'));
 gulp.task('build-zip', ['build-zip-ia32', 'build-zip-x64']);
+
+gulp.task('build-debian', ['renderer'], () => {
+  return build('x64', 'linux')
+    .then(() => buildDebianPkg());
+});
 
 gulp.task('build-installer', ['build', 'build-zip'], () => {
   return buildInstaller('ia32')

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "start": "electron .",
     "dev": "gulp && electron .",
     "build": "gulp build-all",
+    "build-debian": "gulp build-debian",
     "test": "cd app && jest",
     "tdd": "cd app && jest --watch"
   },
@@ -33,5 +34,8 @@
     "gulp-util": "^3.0.7",
     "gulp-zip": "^3.2.0",
     "jest-cli": "12.1.1"
+  },
+  "optionalDependencies": {
+    "electron-installer-debian": "^0.3.0"
   }
 }


### PR DESCRIPTION
- [x] travis setup

- ~~[ ] `platform-util` files search on Linux~~
- ~~[ ] `platform-util` icon protocol realisation to show file icons in the files search on Linux~~
- ~~[ ] `platform-util` window focus management on Linux~~

~~## travis setup~~
~~- auth on travis with github~~
~~- create oauth token at https://github.com/settings/tokens with `repo` scope~~ 

![Demonstration](http://i.imgur.com/Ftqa3f7.png)
- ~~`npm install travis-encrypt -g`~~
- ~~`travis-encrypt -r appetizermonster/hain <token>`~~

~~Token (output from `travis-encrypt` should be replaced in  https://github.com/ewnd9/hain/blob/94814828dbdbb65759740de417c0dc289b6da026/.travis.yml#L9~~

~~Right now there is my token for the test repository https://github.com/ewnd9/hain-travis-publish-playground I had to create separate repo in order to test releases (`git tag`) handling~~
~~### Related~~
~~- [travis doc](https://docs.travis-ci.com/user/deployment/releases/)~~

---

debian package for latest version is available at https://github.com/ewnd9/hain-travis-publish-playground/releases/tag/v0.3.33 // cc @toXel (https://github.com/appetizermonster/hain/pull/48#issuecomment-202776087)

related to https://github.com/appetizermonster/hain/issues/98
