### PR TITLE
Add button API

### DIFF
--- a/app/main-es6/server/server.js
+++ b/app/main-es6/server/server.js
@@ -193,6 +193,11 @@ rpc.on('renderPreview', (evt, msg) => {
   sendmsg('renderPreview', { ticket, pluginId, id, payload });
 });
 
+rpc.on('buttonAction', (evt, msg) => {
+  const { pluginId, id, payload } = msg;
+  sendmsg('buttonAction', { pluginId, id, payload });
+});
+
 rpc.define('close', function* () {
   app.close();
 });

--- a/app/main-es6/worker/plugins.js
+++ b/app/main-es6/worker/plugins.js
@@ -293,6 +293,19 @@ module.exports = (workerContext) => {
     }
   }
 
+  function buttonAction(pluginId, id, payload) {
+    if (plugins[pluginId] === undefined)
+      return;
+    const buttonActionFunc = plugins[pluginId].buttonAction;
+    if (buttonActionFunc === undefined)
+      return;
+    try {
+      buttonActionFunc(id, payload);
+    } catch (e) {
+      logger.log(e.stack || e);
+    }
+  }
+
   function getPrefIds() {
     return pluginPrefIds;
   }
@@ -336,6 +349,7 @@ module.exports = (workerContext) => {
     searchAll,
     execute,
     renderPreview,
+    buttonAction,
     getPrefIds,
     getPreferences,
     updatePreferences,

--- a/app/main-es6/worker/worker.js
+++ b/app/main-es6/worker/worker.js
@@ -88,6 +88,10 @@ const msgHandlers = {
     };
     plugins.renderPreview(pluginId, id, payload, render);
   },
+  buttonAction: (_payload) => {
+    const { pluginId, id, payload } = _payload;
+    plugins.buttonAction(pluginId, id, payload);
+  },
   getPluginPrefIds: (payload) => {
     const prefIds = plugins.getPrefIds();
     procMsg.send('on-get-plugin-pref-ids', prefIds);

--- a/app/renderer-jsx/app.jsx
+++ b/app/renderer-jsx/app.jsx
@@ -7,6 +7,7 @@ const lo_map = require('lodash.map');
 const lo_reject = require('lodash.reject');
 const lo_clamp = require('lodash.clamp');
 const lo_isString = require('lodash.isstring');
+const lo_assign = require('lodash.assign');
 
 const React = require('react');
 const ReactDOM = require('react-dom');
@@ -19,7 +20,7 @@ const Ticket = require('./ticket');
 const searchTicket = new Ticket();
 const previewTicket = new Ticket();
 
-import { TextField, Avatar, SelectableContainerEnhance, List, ListItem, Subheader, FontIcon } from 'material-ui';
+import { TextField, Avatar, SelectableContainerEnhance, List, ListItem, Subheader, FontIcon, IconButton } from 'material-ui';
 import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider';
 import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
 import { Notification } from 'react-notification';
@@ -293,6 +294,39 @@ class AppContainer extends React.Component {
     this.refs.query.focus();
   }
 
+  displayRightButton(i) {
+    const defaultConfig = {
+      className: 'fa fa-info',
+      color: '#009688',
+      hoverColor: '#00695c',
+      tooltip: ''
+    };
+    const result = this.state.results[i];
+    if (!result.button) {
+      return null;
+    }
+    const btnConfig = lo_assign({}, defaultConfig, result.button);
+    const fontIcon = <FontIcon
+      className={ btnConfig.className }
+      onClick={ this.handleRightButtonClick.bind(this, result) }
+      color={ btnConfig.color }
+      hoverColor={ btnConfig.hoverColor }>
+      </FontIcon>;
+    return <IconButton 
+      children={ fontIcon } 
+      tooltip={ btnConfig.tooltip } 
+      tooltipPosition="top-left"
+      style={{ fontSize: 20 }} />;
+  }
+
+  handleRightButtonClick(result, evt) {
+    evt.stopPropagation();
+    const pluginId = result.pluginId;
+    const id = result.id;
+    const payload = result.payload;
+    rpc.send('buttonAction', { pluginId, id, payload });
+  }
+
   parseIconUrl(iconUrl) {
     if (!lo_isString(iconUrl)) {
       return null;
@@ -314,6 +348,7 @@ class AppContainer extends React.Component {
     for (let i = 0; i < results.length; ++i) {
       const result = results[i];
       const avatar = this.parseIconUrl(result.icon);
+      const rightIcon = this.displayRightButton(i);
       if (result.group !== lastGroup) {
         const headerId = `header.${i}`;
         list.push(
@@ -336,6 +371,7 @@ class AppContainer extends React.Component {
           onClick={this.handleItemClick.bind(this, i)}
           onKeyDown={this.handleKeyDown.bind(this)}
           leftAvatar={avatar}
+          rightIconButton={rightIcon}
           />
       );
     }


### PR DESCRIPTION
Hi, I'm back, sorry for the late.

I have finally make the button API. 

So here's some examples for use this API in our plugins : 

```javascript
res.add({
    id: id,
    payload: 'open',
    button: {
        className: 'fa fa-clipboard',
        color: '#5fba7d',
        tooltip: 'Copy to clipboard'
    }
});

function buttonAction(id, payload) {
    ncp.copy(id, function() {
        context.toast.enqueue('Pasted to clipboard !');
    });
}

return { startup, search, execute, renderPreview, buttonAction };
```

```javascript
res.add({
    id: id,
    payload: 'open',
    button: {
        className: 'fa fa-external-link',
        color: 'red',
        hoverColor: 'blue',
        tooltip: 'Go to URL'
    }
});

function buttonAction(id, payload) {
    shell.openExternal(id);
}

return { startup, search, execute, renderPreview, buttonAction };
```

Voilà.

All the options for the button API are optionals, you can check it in the code ;)

The options possible are : 

```javascript
button: {
    className: 'fa fa-icon',
    color: '#color',
    hoverColor: '#color',
    tooltip: 'A tooltip'
}
```

If you think it's good and if you want merge it so I can help you to complete the documentation about this new feature :) . 

Hope you will enjoy.

