### PR TITLE
ClickOnce / .appref-ms app support

### DIFF
--- a/app/main/plugins/hain-plugin-filesearch/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/index.js
@@ -15,7 +15,7 @@ const matchFunc = (filePath, stats) => {
   const ext = path.extname(filePath).toLowerCase();
   if (stats.isDirectory())
     return true;
-  return (ext === '.exe' || ext === '.lnk');
+  return (ext === '.exe' || ext === '.lnk' || ext === '.appref-ms');
 };
 
 function injectEnvVariable(dirPath) {

--- a/app/main/plugins/hain-plugin-filesearch/util.js
+++ b/app/main/plugins/hain-plugin-filesearch/util.js
@@ -15,6 +15,8 @@ function computeRatio(filePath) {
     ratio *= 0.5;
   if (ext === '.lnk')
     ratio *= 1.5;
+  if (ext === '.appref-ms')
+    ratio *= 1.4;
   if (basename.indexOf('uninstall') >= 0 || basename.indexOf('remove') >= 0)
     ratio *= 0.9;
   return ratio;

--- a/app/main/plugins/hain-plugin-filesearch/util.js
+++ b/app/main/plugins/hain-plugin-filesearch/util.js
@@ -11,7 +11,7 @@ function computeRatio(filePath) {
   let ratio = 1;
   const ext = path.extname(filePath).toLowerCase();
   const basename = path.basename(filePath).toLowerCase();
-  if (ext !== '.lnk' && ext !== '.exe')
+  if (ext !== '.lnk' && ext !== '.exe' && ext !== '.appref-ms')
     ratio *= 0.5;
   if (ext === '.lnk')
     ratio *= 1.5;

--- a/app/main/server/app/iconprotocol.js
+++ b/app/main/server/app/iconprotocol.js
@@ -33,7 +33,7 @@ function register() {
       let cacheKey = filePath;
       const extName = path.extname(filePath).toLowerCase();
 
-      if (extName.length > 0 && extName !== '.exe' && extName !== '.lnk') {
+      if (extName.length > 0 && extName !== '.exe' && extName !== '.lnk' && extName !== '.appref-ms') {
         cacheKey = extName;
       } else {
         cacheKey = filePath;


### PR DESCRIPTION
Solves issue / feature request https://github.com/appetizermonster/hain/issues/157

* Passed tests
* built and tested

I had one issue after `npm install` & `npm run dev` and it seems to be because lodash was not included with npm install. I installed the desired lodash version 1.0.2 and then it worked. I didn't want to touch anything but the feature I added.

OS: Windows 10 x64
Node: v4.4.5
npm: 2.15.5