### PR TITLE
Show total download counts in /hpm install

### DIFF
--- a/app/main/plugins/hain-package-manager/downloads-count.js
+++ b/app/main/plugins/hain-package-manager/downloads-count.js
@@ -3,11 +3,27 @@
 const lo_assign = require('lodash.assign');
 const got = require('got');
 
-function _getDownloadsCount(packages, period) {
+const RANGE_ALL = '1000-01-01:3000-01-01';
+const PERIOD_LAST_MONTH = 'last-month';
+
+function _getDownloadCountForPoint(packages, period) {
   const query = packages.join(',');
   const query_enc = encodeURIComponent(query);
   const baseUrl = `http://api.npmjs.org/downloads/point/${period}/${query_enc},`
   return got(baseUrl, { json: true }).then(res => res.body);
+}
+
+function _getDownloadCountForRange(packages, range) {
+  const query = packages.join(',');
+  const query_enc = encodeURIComponent(query);
+  const baseUrl = `http://api.npmjs.org/downloads/range/${range}/${query_enc},`
+  return got(baseUrl, { json: true }).then(res => {
+    const { body } = res;
+    Object.keys(body).forEach(pkg => {
+      body[pkg].downloads = body[pkg].downloads.reduce((sum, dl) => sum + dl.downloads, 0);
+    });
+    return body;
+  });
 }
 
 function splitIntoChunks(arr, chunkSize) {
@@ -24,7 +40,12 @@ function getDownloadsCount(packages, period) {
   const packageChunks = splitIntoChunks(packages, 20);
   const promises = [];
   for (const packageChunk of packageChunks) {
-    const promise = _getDownloadsCount(packageChunk, period || 'last-month');
+    let promise;
+    if (! period) {
+      promise = _getDownloadCountForRange(packageChunk, RANGE_ALL);
+    } else {
+      promise = _getDownloadCountForPoint(packageChunk, period || PERIOD_LAST_MONTH);
+    }
     promises.push(promise);
   }
   return Promise.all(promises).then(results => {

--- a/app/main/plugins/hain-package-manager/index.js
+++ b/app/main/plugins/hain-package-manager/index.js
@@ -152,7 +152,7 @@ module.exports = (context) => {
       const newestPkgNames = newestPackages.map(x => x.name);
       const popularPackages = lo_reject(packages, x => newestPkgNames.indexOf(x.name) >= 0);
 
-      const popularResults = _toSearchResults('install', popularPackages, 'Popular (Monthly)');
+      const popularResults = _toSearchResults('install', popularPackages, 'Popular');
       const newestResults = _toSearchResults('install', newestPackages, 'Newest');
       return newestResults.concat(popularResults);
     }


### PR DESCRIPTION
It was previously showing last month's count which, according to the description, is wrong.

Aside: The value of `RANGE_ALL` was taken from [here](https://github.com/badges/shields/blob/68b26e32d94aa00d9b9d80711df4067db616ce72/server.js#L1450)