### PR TITLE
include links path

### DIFF
--- a/app/main/plugins/hain-plugin-filesearch/preferences.json
+++ b/app/main/plugins/hain-plugin-filesearch/preferences.json
@@ -9,6 +9,7 @@
       },
       "default": [
         "${USERPROFILE}\\Desktop",
+        "${USERPROFILE}\\Links",
         "${ProgramData}\\Microsoft\\Windows\\Start Menu\\Programs",
         "${APPDATA}\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar",
         "${APPDATA}\\Microsoft\\Windows\\Start Menu"


### PR DESCRIPTION
Include items from Windows 10's  Quick Access list, for example, _Downloads_.