### PR TITLE
Bugfix for Windows, changes from macos branch broke windows.

### DIFF
--- a/app/main/server/app/app-icon-protocol.js
+++ b/app/main/server/app/app-icon-protocol.js
@@ -8,7 +8,6 @@ const electron = require('electron');
 const protocol = electron.protocol;
 
 const conf = require('../../conf');
-const macBundleUtil = require('../../../native/mac-bundle-util');
 
 function hashPath(bundlePath) {
   return crypto.createHash('md5').update(bundlePath).digest('hex');
@@ -17,6 +16,8 @@ function hashPath(bundlePath) {
 function register() {
   if (process.platform !== 'darwin')
     return;
+
+  const macBundleUtil = require('../../../native/mac-bundle-util');
 
   protocol.registerFileProtocol('appicon', (req, callback) => {
     const cacheDir = path.join(conf.HAIN_USER_PATH, 'AppIcons');

--- a/app/main/server/app/auto-launcher/index.js
+++ b/app/main/server/app/auto-launcher/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let moduleName = require('./win32');
+let moduleName = './win32';
 
 if (process.platform === 'darwin')
   moduleName = './darwin';


### PR DESCRIPTION
* ModuleName should have been a string, was failing on trying to require a non-string parameter on auto-launcher.js:8
* For app-icon-protocol.js, when line 11 executed unconditionally on windows it would fail with an invalid win32 image.  Moved the require down below the platform check.

@appetizermonster: Some of this functionality should be refactored into a class hierarchy and use polymorphism I think.  I'm not sure exactly what this registerFileProtocol() business is, but looks like icon:// and appicon:// have the same ending purpose.  Seems like we should have just one protocol prefix (icon://) so plugin authors don't have to use different prefixes, and again the common functionality can be put into a single base class (IconProtocol) and have sub-classes of DarwinIconProtocol or WindowsIconProtocol, etc.

LMK what you think of that, if you don't know what I'm meaning by this, I could refactor it into a cleaner abstraction to show you what I mean... LMK
