### PR TITLE
Pass on to execute() in plugins the modifier keystate at the time of enter being pressed.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "airbnb-base",
   "rules": {
-    "comma-dangle": ["error", "never"],
+    "comma-dangle": ["warn", "only-multiline"],
     "no-unused-vars": "warn",
     "camelcase": "off",
     "object-shorthand": "off",
@@ -20,7 +20,9 @@
     "max-len": "off",
     "no-underscore-dangle": "off",
     "strict": "off",
-    "global-require": "off"
+    "global-require": "off",
+    "no-restricted-syntax": "off",
+    "no-multi-spaces": "off"
    },
    "env": {
      "jest": true

--- a/app/main/plugins/hain-commands/index.js
+++ b/app/main/plugins/hain-commands/index.js
@@ -115,7 +115,7 @@ module.exports = (context) => {
     }));
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     const actions = {
       'redirect_about': () => {
         app.setQuery('/hain about');

--- a/app/main/plugins/hain-package-manager/index.js
+++ b/app/main/plugins/hain-package-manager/index.js
@@ -206,7 +206,7 @@ module.exports = (context) => {
     app.setQuery(`${PREFIX} `);
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     const funcs = {
       'install': () => {
         installPackage(id);

--- a/app/main/plugins/hain-plugin-filesearch/darwin/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/darwin/index.js
@@ -82,7 +82,7 @@ module.exports = (context) => {
     });
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     if (fs.existsSync(id) === false) {
       toast.enqueue('Sorry, Could\'nt Find a File');
       return;

--- a/app/main/plugins/hain-plugin-filesearch/win32/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/win32/index.js
@@ -83,7 +83,7 @@ module.exports = (context) => {
     });
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     if (fs.existsSync(id) === false) {
       toast.enqueue('Sorry, Could\'nt Find a File');
       return;

--- a/app/main/plugins/hain-plugin-math/index.js
+++ b/app/main/plugins/hain-plugin-math/index.js
@@ -49,7 +49,7 @@ module.exports = (context) => {
     } catch (e) { }
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     app.setQuery(`=${payload}`);
     clipboard.writeText(payload);
     toast.enqueue(`${payload} has copied into clipboard`);

--- a/app/main/plugins/hain-plugin-url/index.js
+++ b/app/main/plugins/hain-plugin-url/index.js
@@ -34,7 +34,7 @@ module.exports = (context) => {
     };
   }
 
-  function execute(id, payload) {
+  function execute(id, payload, extra) {
     const protocol_re = /https?:\/\//i;
     let url = id;
     if (protocol_re.test(url) === false) {

--- a/app/main/server/app/app-icon-protocol.js
+++ b/app/main/server/app/app-icon-protocol.js
@@ -8,7 +8,6 @@ const electron = require('electron');
 const protocol = electron.protocol;
 
 const conf = require('../../conf');
-const macBundleUtil = require('../../../native/mac-bundle-util');
 
 function hashPath(bundlePath) {
   return crypto.createHash('md5').update(bundlePath).digest('hex');
@@ -17,6 +16,8 @@ function hashPath(bundlePath) {
 function register() {
   if (process.platform !== 'darwin')
     return;
+
+  const macBundleUtil = require('../../../native/mac-bundle-util');
 
   protocol.registerFileProtocol('appicon', (req, callback) => {
     const cacheDir = path.join(conf.HAIN_USER_PATH, 'AppIcons');

--- a/app/main/server/app/auto-launcher/index.js
+++ b/app/main/server/app/auto-launcher/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let moduleName = require('./win32');
+let moduleName = './win32';
 
 if (process.platform === 'darwin')
   moduleName = './darwin';

--- a/app/main/server/app/ui/main-window.js
+++ b/app/main/server/app/ui/main-window.js
@@ -66,8 +66,8 @@ module.exports = class MainWindow {
       this.workerProxy.searchAll(ticket, query);
     });
     this.rpc.define('execute', (__payload) => {
-      const { context, id, payload } = __payload;
-      this.workerProxy.execute(context, id, payload);
+      const { context, id, payload, extra } = __payload;
+      this.workerProxy.execute(context, id, payload, extra);
     });
     this.rpc.define('renderPreview', (__payload) => {
       const { ticket, context, id, payload } = __payload;

--- a/app/main/server/worker/worker-proxy.js
+++ b/app/main/server/worker/worker-proxy.js
@@ -10,8 +10,8 @@ module.exports = class WorkerProxy {
   searchAll(ticket, query) {
     this.workerClient.rpc.call('searchAll', { ticket, query });
   }
-  execute(context, id, payload) {
-    this.workerClient.rpc.call('execute', { context, id, payload });
+  execute(context, id, payload, extra) {
+    this.workerClient.rpc.call('execute', { context, id, payload, extra });
   }
   renderPreview(ticket, context, id, payload) {
     this.workerClient.rpc.call('renderPreview', { ticket, context, id, payload });

--- a/app/main/worker/index.js
+++ b/app/main/worker/index.js
@@ -54,8 +54,8 @@ rpc.define('searchAll', (payload) => {
 });
 
 rpc.define('execute', (__payload) => {
-  const { context, id, payload } = __payload;
-  plugins.execute(context, id, payload);
+  const { context, id, payload, extra } = __payload;
+  plugins.execute(context, id, payload, extra);
 });
 
 rpc.define('renderPreview', (__payload) => {

--- a/app/main/worker/indexer/manager.js
+++ b/app/main/worker/indexer/manager.js
@@ -12,7 +12,7 @@ const CONTEXT = '@indexer';
 class IndexerManager {
   constructor(localStorage) {
     this.indexers = {};
-    this.executeFunc = (pluginId, id, payload) => { };
+    this.executeFunc = (pluginId, id, payload, extra) => { };
     this.itemPriorityManager = new ItemPriorityManager(localStorage);
     this.itemPriorityManager.load();
   }
@@ -57,12 +57,12 @@ class IndexerManager {
     this.indexers[pluginId] = indexer;
     return indexer;
   }
-  execute(pluginId, id, extraPayload) {
+  execute(pluginId, id, extraPayload, extra) {
     if (!this.executeFunc) {
       logger.error('Can\'t find a execute function');
       return;
     }
-    this.executeFunc(pluginId, id, extraPayload);
+    this.executeFunc(pluginId, id, extraPayload, extra);
 
     const itemPriorityId = this.makeItemPriorityId(pluginId, id);
     this.itemPriorityManager.markItemHasExecuted(itemPriorityId);

--- a/app/main/worker/plugins.js
+++ b/app/main/worker/plugins.js
@@ -172,7 +172,7 @@ module.exports = (workerContext) => {
     resFunc({ type: 'add', payload: indexerManager.search(query) });
   }
 
-  function execute(context, id, payload) {
+  function execute(context, id, payload, extra) {
     const isRedirect = (!context && lo_isString(payload));
     if (isRedirect) {
       workerContext.app.setQuery(payload);
@@ -180,21 +180,21 @@ module.exports = (workerContext) => {
     }
 
     if (context === IndexerManager.CONTEXT)
-      return executeOnIndexer(id, payload);
-    return executeOnPlugin(context, id, payload);
+      return executeOnIndexer(id, payload, extra);
+    return executeOnPlugin(context, id, payload, extra);
   }
 
-  function executeOnIndexer(id, payload) {
+  function executeOnIndexer(id, payload, extra) {
     const { pluginId, extraPayload } = payload;
-    indexerManager.execute(pluginId, id, extraPayload);
+    indexerManager.execute(pluginId, id, extraPayload, extra);
   }
 
-  function executeOnPlugin(pluginId, id, payload) {
+  function executeOnPlugin(pluginId, id, payload, extra) {
     const executeFunc = plugins[pluginId].execute;
     if (executeFunc === undefined)
       return;
     try {
-      executeFunc(id, payload);
+      executeFunc(id, payload, extra);
     } catch (e) {
       logger.error(e.stack || e);
     }

--- a/app/renderer-jsx/app.jsx
+++ b/app/renderer-jsx/app.jsx
@@ -195,13 +195,23 @@ class AppContainer extends React.Component {
     }, CLEAR_INTERVAL);
   }
 
-  execute(item) {
+  execute(item, evt) {
     if (item === undefined)
       return;
+    const e = evt.nativeEvent;
     const params = {
       context: item.context,
       id: item.id,
-      payload: item.payload
+      payload: item.payload,
+      extra: {
+        keys: {
+          altKey: evt.nativeEvent.altKey,
+          ctrlKey: evt.nativeEvent.ctrlKey,
+          shiftKey: evt.nativeEvent.shiftKey,
+          metaKey: evt.nativeEvent.metaKey,
+          modifierBitfield: (e.ctrlKey) + (e.altKey << 1) + (e.shiftKey << 2) + (e.metaKey << 3),
+        },
+      },
     };
     rpc.call('execute', params);
   }
@@ -227,7 +237,7 @@ class AppContainer extends React.Component {
     rpc.call('renderPreview', { ticket, context, id, payload });
   }
 
-  handleSelection(selectionDelta) {
+  handleSelection(selectionDelta, evt) {
     const results = this.state.results;
     const upperSelectionIndex = results.length - 1;
 
@@ -241,7 +251,7 @@ class AppContainer extends React.Component {
     this.scrollTo(newSelectionIndex);
   }
 
-  handleEsc() {
+  handleEsc(evt) {
     const query = this.state.query;
     if (query === undefined || query.length <= 0) {
       rpc.call('close');
@@ -250,13 +260,13 @@ class AppContainer extends React.Component {
     this.setQuery('');
   }
 
-  handleEnter() {
+  handleEnter(evt) {
     const results = this.state.results;
     const selectionIndex = this.state.selectionIndex;
-    this.execute(results[selectionIndex]);
+    this.execute(results[selectionIndex], evt);
   }
 
-  handleTab() {
+  handleTab(evt) {
     const results = this.state.results;
     const selectionIndex = this.state.selectionIndex;
     const item = results[selectionIndex];
@@ -289,15 +299,15 @@ class AppContainer extends React.Component {
     const selectedHandler = keyHandlers[key];
     if (evt.ctrlKey) {
       if (selectedHandlerForCtrl !== undefined) {
-        selectedHandlerForCtrl();
+        selectedHandlerForCtrl(evt);
         evt.preventDefault();
       } else if (selectedHandler !== undefined) {
-        selectedHandler();
+        selectedHandler(evt);
         evt.preventDefault();
       }
     } else {
       if (selectedHandler !== undefined) {
-        selectedHandler();
+        selectedHandler(evt);
         evt.preventDefault();
       }
     }
@@ -315,7 +325,7 @@ class AppContainer extends React.Component {
   }
 
   handleItemClick(i, evt) {
-    this.execute(this.state.results[i]);
+    this.execute(this.state.results[i], evt);
   }
 
   handleKeyboardFocus(evt) {


### PR DESCRIPTION
Add an "extra" parameter to the execute() plugin function.

The "extra" parameter is an object.  Re: #189 

At the moment it has a keys object which contains #(alt|ctrl|shift|meta)Key# fields as well as a modifierBitfield which is a bitfield of the "state" of the set of modifiers as detailed below:

| Bit | Modifier |
|----|-----------|
| 1 | ctrlKey |
| 2 | altKey |
| 4 | shiftKey |
| 8 | metaKey |

Also made some changes to the eslint configuration. **Seems much of the code has violations of the existing eslint options already**, perhaps a solid review of what is set, what is possible should be done and an effort to normalize it done.