### PR TITLE
Fix travis ci release draft name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ deploy:
   overwrite: true
   skip_cleanup: true
   draft: true
+  name: $TRAVIS_TAG
   on:
     repo: hainproject/hain
     tags: true


### PR DESCRIPTION
Currently, Travis CI creates a release draft named `Draft`, by the way, AppVeyor creates a release draft named `vX.X.X`, it's conflicting for same version release.

So I made Travis CI to name the release draft `vX.X.X` just like AppVeyor.
But I'm not sure if it's working 😢 

Any ideas?